### PR TITLE
update API call to be POST request instead of GET

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ function App() {
         setWebPage(undefined);
         setNodeInFocus(undefined);
         setNetwork(undefined);
-        axios.get("webPage", {params: {url}})
+        axios.post("/pages/", { url })
             .then((response) => {
                 setWebPage(response.data);
             })


### PR DESCRIPTION
- Altered the API call to backend to be a POST request rather than GET.
- Using a POST request makes sense because A) We are now saving the web page in a database so we are technically creating a resource B) This leaves `GET /pages/{id}` available for the request that will be sent when a user wants to load an existing page.